### PR TITLE
Change smb.conf workgroup assignment NethServer/dev#5116

### DIFF
--- a/root/etc/e-smith/templates/etc/samba/smb.conf/00workgroup
+++ b/root/etc/e-smith/templates/etc/samba/smb.conf/00workgroup
@@ -1,0 +1,14 @@
+{
+    #
+    # 00workgroup
+    #
+
+    $workgroup = 'WORKGROUP';
+    if(defined $smb{'Workgroup'} && $smb{'Workgroup'}) {
+        $workgroup = $smb{'Workgroup'};
+    } elsif($sssd{'Provider'} eq 'ad') {
+        $workgroup = uc((split('\.', $DomainName))[0]);
+    }
+    $workgroup = substr($workgroup, 0, 15);
+    '';
+}

--- a/root/etc/e-smith/templates/etc/samba/smb.conf/10base
+++ b/root/etc/e-smith/templates/etc/samba/smb.conf/10base
@@ -2,7 +2,7 @@
 #
 # 10base
 #
-workgroup = { $sssd{'Provider'} eq 'ad' ? uc((split('\.', $DomainName))[0]) : ($smb{'Workgroup'} || 'WORKGROUP') }
+workgroup = { $workgroup }
 server string = NethServer {$sysconfig{'Version'} . ' ' . $sysconfig{'Release'}} (Samba %v)
 security = { $sssd{'Provider'} eq 'ad' ? 'ADS' : 'user' }
 { $sssd{'Provider'} eq 'ad' ? '' : '# ' }realm = { uc($DomainName) }

--- a/root/usr/share/nethesis/NethServer/Module/Sssd/Index.php
+++ b/root/usr/share/nethesis/NethServer/Module/Sssd/Index.php
@@ -36,6 +36,8 @@ class Index extends \Nethgui\Controller\AbstractController
         $this->provider = $this->getPlatform()->getDatabase('configuration')->getProp('sssd', 'Provider');
         if ($this->getRequest()->isValidated()) {
             if ($this->provider === 'ad') {
+                $workgroup = trim($this->getPlatform()->exec('testparm -s -d 0 --parameter-name=workgroup 2>/dev/null')->getOutput());
+                $this->details .= "NetBIOS domain name: ${workgroup}\n";
                 $this->details .= $this->getPlatform()->exec('/usr/bin/sudo /usr/bin/net ads info 2>&1')->getOutput() . "\n\n";
                 $this->details .= $this->getPlatform()->exec('/usr/bin/sudo /usr/bin/net ads testjoin 2>&1')->getOutput() . "\n";
 


### PR DESCRIPTION
1. If the smb/Workgroup prop is set, it takes precedence. The smb key is
   not installed, but can be set manually by the admin. This is required to
   join AD domains where the netBIOS domain name is not derived from the
   DNS domain suffix.

2. Ensure the netBIOS domain name is 15 chars max.

NethServer/dev#5116