### PR TITLE
Don't rely on DNS to find LDAP server in AD

### DIFF
--- a/lib/perl/NethServer/SSSD.pm
+++ b/lib/perl/NethServer/SSSD.pm
@@ -22,7 +22,6 @@ package NethServer::SSSD;
 
 use strict;
 use esmith::ConfigDB;
-use Net::LDAP;
 use NethServer::Password;
 use Carp;
 use URI;
@@ -76,7 +75,7 @@ false otherwise
 
 sub isLdap {
     my $self = shift;
-    return ( ($self->{'Provider'} || '') eq 'ldap');
+    return ( $self->{'Provider'} eq 'ldap');
 }
 
 
@@ -89,7 +88,7 @@ false otherwise
 
 sub isAD {
     my $self = shift;
-    return ( ($self->{'Provider'} || '') eq 'ad');
+    return ( $self->{'Provider'} eq 'ad');
 }
 
 
@@ -143,7 +142,7 @@ otherwise a base DN calculated from the server domain.
 
 sub baseDN {
     my $self = shift;
-    return $self->{'BaseDN'} if (defined $self->{'BaseDN'} && $self->{'BaseDN'});
+    return $self->{'BaseDN'} if ($self->{'BaseDN'});
 
     return $self->isAD() ? __domain2suffix() : __builtinSuffix();
 }
@@ -158,9 +157,9 @@ otherwise a bind DN calculated from the server domain.
 sub bindDN {
     my $self = shift;
     my $suffix = '';
-    return $self->{'BindDN'} if (defined $self->{'BindDN'} && $self->{'BindDN'});
+    return $self->{'BindDN'} if ($self->{'BindDN'});
 
-    if (defined $self->{'BaseDN'} && $self->{'BaseDN'}) {
+    if ($self->{'BaseDN'}) {
         $suffix = $self->{'BaseDN'};
     } else {
         $suffix = $self->isAD() ? __domain2suffix() : __builtinSuffix();
@@ -185,9 +184,9 @@ otherwise a user DN calculated from the server domain.
 sub userDN {
     my $self = shift;
     my $suffix = '';
-    return $self->{'UserDN'} if (defined $self->{'UserDN'} && $self->{'UserDN'});
+    return $self->{'UserDN'} if ($self->{'UserDN'});
 
-    if (defined $self->{'BaseDN'} && $self->{'BaseDN'}) {
+    if ($self->{'BaseDN'}) {
         $suffix = $self->{'BaseDN'};
     } else {
         $suffix = $self->isAD() ? __domain2suffix() : __builtinSuffix();
@@ -210,9 +209,9 @@ otherwise a group DN calculated from the server domain.
 sub groupDN {
     my $self = shift;
     my $suffix = '';
-    return $self->{'UserDN'} if (defined $self->{'UserDN'} && $self->{'UserDN'});
+    return $self->{'UserDN'} if ($self->{'UserDN'});
 
-    if (defined $self->{'BaseDN'} && $self->{'BaseDN'}) {
+    if ($self->{'BaseDN'}) {
         $suffix = $self->{'BaseDN'};
     } else {
         $suffix = $self->isAD() ? __domain2suffix() : __builtinSuffix();
@@ -235,7 +234,7 @@ an empty string otherwise.
 
 sub bindPassword {
     my $self = shift;
-    return $self->{'BindPassword'} if (defined $self->{'BindPassword'} && $self->{'BindPassword'});
+    return $self->{'BindPassword'} if ($self->{'BindPassword'});
 
     if ($self->isLdap() && ($self->host() eq 'localhost' || $self->host() eq '127.0.0.1') ) {
         return NethServer::Password::store('ldapservice');
@@ -280,7 +279,7 @@ Return LDAP bind user BindUser if set,
 
 sub bindUser {
     my $self = shift;
-    return $self->{'BindUser'} if (defined $self->{'BindUser'} && $self->{'BindUser'});
+    return $self->{'BindUser'} if ($self->{'BindUser'});
 
     if ($self->isLdap() && ($self->host() eq 'localhost' || $self->host() eq '127.0.0.1') ) {
         return 'ldapservice';
@@ -303,16 +302,22 @@ Create a NethServer::SSSD instance.
 sub new 
 {
     my $class = shift;
-    my $self = {};
-    
+
     my $db = esmith::ConfigDB->open_ro();
     my $sssd = $db->get('sssd') || die("No sssd key defined");
-    my %props = $sssd->props();
-    foreach my $key (keys %props) { 
-       $self->{$key} = $props{$key};
-    }
-    $self->{'config'} = $db;
-    if (!defined $self->{'LdapURI'} || $self->{'LdapURI'} eq '') {
+
+    my $self = {
+        'AdDns' => '',
+        'Provider' => '',
+        'LdapURI' => '',
+        'BaseDN' => '',
+        'BindDN' => '',
+        'BindPassword' => '',
+        'UserDN' => '',
+        $sssd->props()
+    };
+
+    if ($self->{'LdapURI'} eq '') {
         my $host = 'localhost';
         if($self->{'Provider'} eq 'ad') {
             $host = $db->get('DomainName')->value();


### PR DESCRIPTION
- Remove external dependencies on remote DNS and local LDAP probes
- Code refactor: always define internal properties as empty strings

This PR could fix this problem (still investigating)
http://community.nethserver.org/t/sogo-ldap-bind-failures-after-backup-config-restore/5005/30?u=davidep