### PR TITLE
Disable automatic machine password renewal NethServer/dev#5177

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -27,11 +27,14 @@ use esmith::Build::CreateLinks  qw(:all);
 # event nethserver-sssd-update event
 #
 event_templates('nethserver-sssd-update', qw(
+    /etc/sssd/sssd.conf
     /etc/openldap/ldap.conf
 ));
-
 event_actions('nethserver-sssd-update', qw(
     initialize-default-databases   00
+));
+event_services('nethserver-sssd-update', qw(
+    sssd restart
 ));
 
 #

--- a/root/etc/e-smith/templates/etc/sssd/sssd.conf/01provider_config
+++ b/root/etc/e-smith/templates/etc/sssd/sssd.conf/01provider_config
@@ -17,6 +17,7 @@
         $provider_config .= "krb5_realm = " . uc($DomainName) . "\n";
         $provider_config .= "krb5_store_password_if_offline = True\n";
         $provider_config .= "ldap_id_mapping = True\n";
+        $provider_config .= "ad_maximum_machine_account_password_age = 0\n";
     }
 
     '';

--- a/root/usr/share/nethesis/NethServer/Module/SssdConfig/AuthProvider/Authenticate.php
+++ b/root/usr/share/nethesis/NethServer/Module/SssdConfig/AuthProvider/Authenticate.php
@@ -43,6 +43,8 @@ class Authenticate extends \Nethgui\Controller\AbstractController implements \Ne
             return;
         }
 
+        $this->getPlatform()->signalEvent('nethserver-sssd-leave');
+
         $domain = \Nethgui\array_end(\explode('.', \gethostname(), 2));
 
         $ph = popen('/usr/bin/sudo /usr/sbin/realm join ' . $domain, 'w');


### PR DESCRIPTION
Disable the feature introduced by sssd-1.14 that breaks our configuration.

The following command changes the machine password and system keytab, like ``adcli``. It works for us:

    net ads changetrustpw

NethServer/dev#5177