### PR TITLE
Fix domain join credentials NethServer/dev#5181

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/SssdConfig/AuthProvider/Authenticate.php
+++ b/root/usr/share/nethesis/NethServer/Module/SssdConfig/AuthProvider/Authenticate.php
@@ -47,7 +47,7 @@ class Authenticate extends \Nethgui\Controller\AbstractController implements \Ne
 
         $domain = \Nethgui\array_end(\explode('.', \gethostname(), 2));
 
-        $ph = popen('/usr/bin/sudo /usr/sbin/realm join ' . $domain, 'w');
+        $ph = popen(sprintf('/usr/bin/sudo /usr/sbin/realm join -U %s %s', escapeshellarg($this->parameters['login']), escapeshellarg($domain)), 'w');
         fwrite($ph, $this->parameters['password'] . "\n");
         $err = pclose($ph);
 


### PR DESCRIPTION
The login parameter was not passed to the ``realm join`` command.

NethServer/dev#5181