### PR TITLE
Backup of Samba secrets.tdb

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -28,6 +28,7 @@ use esmith::Build::CreateLinks  qw(:all);
 #
 event_templates('nethserver-sssd-update', qw(
     /etc/sssd/sssd.conf
+    /etc/samba/smb.conf
     /etc/openldap/ldap.conf
 ));
 event_actions('nethserver-sssd-update', qw(
@@ -115,4 +116,20 @@ event_actions('password-policy-update', qw(
 # actions for myhostname validator
 validator_actions('myhostname', qw(
     failifjoin 00
+));
+
+#--------------------------------------------------
+# actions for post-restore-config event
+#--------------------------------------------------
+
+event_actions('post-restore-config', qw(
+    nethserver-sssd-restore-tdb 40
+));
+
+#--------------------------------------------------
+# actions for pre-backup-config event
+#--------------------------------------------------
+
+event_actions('pre-backup-config', qw(
+    nethserver-sssd-backup-tdb 40
 ));

--- a/nethserver-sssd.spec
+++ b/nethserver-sssd.spec
@@ -14,6 +14,7 @@ Requires: mailx, postfix, anacron
 Requires:  samba-common-tools
 Requires: krb5-workstation
 Requires: python-tdb
+Requires: tdb-tools
 
 %description
 NethServer SSSD configuration

--- a/root/etc/backup-config.d/nethserver-sssd.include
+++ b/root/etc/backup-config.d/nethserver-sssd.include
@@ -1,1 +1,3 @@
 /etc/krb5.keytab
+/var/lib/nethserver/backup/secrets_tdb.dump
+

--- a/root/etc/e-smith/events/actions/nethserver-sssd-backup-tdb
+++ b/root/etc/e-smith/events/actions/nethserver-sssd-backup-tdb
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+dest=/var/lib/nethserver/backup/secrets_tdb.dump
+
+if [[ ! -f $dest ]]; then
+    exit 0
+fi
+
+umask 077
+/usr/bin/tdbdump /var/lib/samba/private/secrets.tdb > $dest
+chmod 0600 $dest

--- a/root/etc/e-smith/events/actions/nethserver-sssd-restore-tdb
+++ b/root/etc/e-smith/events/actions/nethserver-sssd-restore-tdb
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+if [ -f /var/lib/nethserver/backup/secrets_tdb.dump ]; then
+   if [ -f /var/lib/samba/private/secrets.tdb ]; then # backup old tdb
+       mv /var/lib/samba/private/secrets.tdb /var/lib/samba/private/secrets.tdb.bak
+   fi
+   /usr/bin/tdbrestore /var/lib/samba/private/secrets.tdb < /var/lib/nethserver/backup/secrets_tdb.dump
+   chmod 600 /var/lib/samba/private/secrets.tdb
+fi


### PR DESCRIPTION
The secrets.tdb file contains the machine password required to join an
AD domain (both local and remote).

NethServer/dev#5188