### PR TITLE
Always expand nethserver-sssd.include template

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-sssd-initkeytabs
+++ b/root/etc/e-smith/events/actions/nethserver-sssd-initkeytabs
@@ -26,4 +26,6 @@ if [[ $(/sbin/e-smith/config getprop sssd Provider) != "ad" ]]; then
     exit 0
 fi
 
+/sbin/e-smith/expand-template /etc/backup-config.d/nethserver-sssd.include
+
 exec ${smbads} initkeytab


### PR DESCRIPTION
If a package invokes nethserver-sssd-initkeytabs, it surely needs to expand the new
nethserver-sssd.include template, too. See #44

We can execute both calls in the same action, or as alternative, the package must add nethserver-sssd.include to its templates list.