### PR TITLE
LDAP probe validator

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -163,3 +163,10 @@ validator_actions('dcipaddr', qw(
     ipgreenandbridged 20
 ));
 
+
+#
+# ldap probe validator
+#
+validator_actions('ldap-probe', qw(
+    ldap-check-connect 20
+));

--- a/root/etc/e-smith/validators/actions/ldap-check-connect
+++ b/root/etc/e-smith/validators/actions/ldap-check-connect
@@ -1,0 +1,39 @@
+#!/usr/bin/perl
+
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+use strict;
+use Net::LDAP;
+
+my $server = shift || die("Missing server address argument");
+my $port = shift || '';
+my $timeout = 2;
+
+my $ldap = Net::LDAP->new("ldaps://$server" . ($port ? ":$port" : ""), timeout => $timeout, verify => 'none')
+        || Net::LDAP->new("ldap://$server" . ($port ? ":$port" : ""), timeout => $timeout);
+
+if ( !$ldap ) {
+    exit(1);
+}
+
+my $dse = $ldap->root_dse() || exit(1);
+
+exit(0);

--- a/root/usr/sbin/account-provider-test
+++ b/root/usr/sbin/account-provider-test
@@ -140,13 +140,13 @@ if($cmd eq 'dump') {
     my %attrs = ();
     my $response;
 
-    my $ldap = Net::LDAP->new("ldap://$server" . ($port ? ":$port" : ""), timeout => $timeout)
-        || Net::LDAP->new("ldaps://$server" . ($port ? ":$port" : ""), timeout => $timeout, verify => 'none')
+    my $ldap = Net::LDAP->new("ldaps://$server" . ($port ? ":$port" : ""), timeout => $timeout, verify => 'none')
+        || Net::LDAP->new("ldap://$server" . ($port ? ":$port" : ""), timeout => $timeout)
     ;
 
     if ( ! $ldap) {
         warn "Connection failed to LDAP server $server $port\n";
-        $attrs{'LdapURI'} = "ldap://$server";
+        exit(1);
     } else {
         $attrs{'LdapURI'} = $ldap->{'net_ldap_uri'};
         my $dse = $ldap->root_dse();

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_SssdConfig.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_SssdConfig.php
@@ -117,8 +117,8 @@ $L['CreateDomain_label'] = 'Create domain';
 
 $L['installSuccessAd_notification'] = 'Active Directory local accounts provider was installed correctly';
 $L['LocalAdProvider_header'] = 'Active Directory local accounts provider for ${0}';
-$L['LocalAdUpdate_label'] = 'Install DC update';
+$L['LocalAdUpdate_label'] = 'Update DC';
 $L['LocalAdProviderUninstall_label'] = 'Uninstall';
 $L['sambaUpdateIsAvailable_notification'] = "An update to the Domain Controller package is available";
-$L['LocalAdUpdate_header'] = 'Install DC update';
+$L['LocalAdUpdate_header'] = 'Update DC';
 $L['LocalAdUpdate_message'] = 'This operation might require the download of additional packages. The Domain Controller will be restarted after the software has been updated';

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_SssdConfig.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_SssdConfig.php
@@ -52,6 +52,7 @@ $L['LdapRemoteTcpPort_label'] = 'TCP port';
 $L['LdapRemoteIp_header'] = 'Bind to a remote LDAP server';
 $L['LdapRemoteBind_label'] = 'Check configuration';
 $L['probeLdapSuccess_warning'] = 'Review and save the LDAP settings to finish the configuration';
+$L['valid_platform,ldap-probe,ldap-check-connect,1'] = 'Server connection error or invalid service port';
 
 $L['BindType_anonymous_label'] = 'Anonymous bind';
 $L['BindType_authenticated_label'] = 'Authenticated bind';

--- a/root/usr/share/nethesis/NethServer/Module/SssdConfig/Wizard/LdapRemoteIp.php
+++ b/root/usr/share/nethesis/NethServer/Module/SssdConfig/Wizard/LdapRemoteIp.php
@@ -76,4 +76,11 @@ class LdapRemoteIp extends \Nethgui\Controller\AbstractController {
         return FALSE;
     }
 
+    public function validate(\Nethgui\Controller\ValidationReportInterface $report)
+    {
+        $this->getValidator('LdapRemoteIpAddress')
+            ->platform('ldap-probe', $this->parameters['LdapRemoteIpAddress'], $this->parameters['LdapRemoteTcpPort']);
+        parent::validate($report);
+    }
+
 }


### PR DESCRIPTION
Improve LDAP probing:
- add a system validtor to check if the server is reachable
- return empty json if probe fails

NethServer/dev#5253