### PR TITLE
Drop SSSD "legacy" domain

### DIFF
--- a/root/etc/e-smith/templates/etc/sssd/sssd.conf/10base
+++ b/root/etc/e-smith/templates/etc/sssd/sssd.conf/10base
@@ -1,5 +1,6 @@
 [sssd]
-domains = {{ $DomainName }}, legacy
+domains = { $DomainName }
 config_file_version = 2
 services = nss, pam
+default_domain_suffix = { $DomainName }
 

--- a/root/etc/e-smith/templates/etc/sssd/sssd.conf/21domain_legacy
+++ b/root/etc/e-smith/templates/etc/sssd/sssd.conf/21domain_legacy
@@ -1,6 +1,0 @@
-[domain/legacy]
-use_fully_qualified_names = False
-{
-    $OUT = $provider_config;
-}
-


### PR DESCRIPTION
Use "default_domain_suffix" option instead.

NethServer/dev#5234