### PR TITLE
Allow change the Workgroup in ns6 LDAP upgrade

### DIFF
--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_SssdConfig.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_SssdConfig.php
@@ -83,7 +83,10 @@ $L['unbindSuccess_notification'] = 'The remote accounts provider was succesfully
 
 $L['LocalLdapProviderUpgrade_label'] = 'Upgrade to Active Directory';
 $L['LocalLdapUpgrade_header'] = 'Upgrade to Active Directory';
-$L['LocalLdapUpgrade_message'] = 'This operation is not reversible! The local LDAP database supports the Samba schema and can be upgraded to a local Active Directory accounts provider, preserving users, passwords, groups and computer accounts.';
+$L['LocalLdapUpgrade_message1'] = 'This operation is not reversible! The LDAP database can be upgraded to a local Active Directory accounts provider.';
+$L['LocalLdapUpgrade_PDC_message1'] = 'Users, passwords, groups and computer accounts are preserved.';
+$L['LocalLdapUpgrade_WS_message1'] = 'Users, passwords and groups are preserved; however shared folder connections require different credentials!';
+$L['LocalLdapUpgrade_WS_message2'] = 'When connecting to a shared folder, the NetBIOS domain name must be either prefixed to the user name (i.e. "MYDOMAIN\username"), or provided by other means.';
 $L['LdapUpgradeButton_label'] = 'Upgrade';
 $L['canUpgradeToSamba_notification'] = 'The local LDAP accounts provider can be upgraded to Samba Active Directory';
 

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_SssdConfig.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_SssdConfig.php
@@ -85,6 +85,7 @@ $L['LocalLdapProviderUpgrade_label'] = 'Upgrade to Active Directory';
 $L['LocalLdapUpgrade_header'] = 'Upgrade to Active Directory';
 $L['LocalLdapUpgrade_message'] = 'This operation is not reversible! The local LDAP database supports the Samba schema and can be upgraded to a local Active Directory accounts provider, preserving users, passwords, groups and computer accounts.';
 $L['LdapUpgradeButton_label'] = 'Upgrade';
+$L['canUpgradeToSamba_notification'] = 'The local LDAP accounts provider can be upgraded to Samba Active Directory';
 
 $L['AdJoinMember_header'] = 'Join Active Directory as new member';
 $L['AdDns_label'] = 'AD DNS server';

--- a/root/usr/share/nethesis/NethServer/Module/SssdConfig/LocalLdapProvider.php
+++ b/root/usr/share/nethesis/NethServer/Module/SssdConfig/LocalLdapProvider.php
@@ -40,6 +40,11 @@ class LocalLdapProvider extends \Nethgui\Controller\AbstractController implement
         if(isset($result)) {
             return $result;
         }
+        if( ! $this->isFirstChild()) {
+            $result = FALSE;
+            return FALSE;
+        }
+
         $process = $this->getPlatform()->exec("ldapsearch -LLL -H ldapi:/// -x -w '' -D '' -b dc=directory,dc=nh objectClass=sambaDomain 2>/dev/null | grep -q '^sambaDomainName: '");
         if($process->getExitCode() === 0) {
             $result = TRUE;
@@ -47,6 +52,11 @@ class LocalLdapProvider extends \Nethgui\Controller\AbstractController implement
             $result = FALSE;
         }
         return $result;
+    }
+
+    protected function isFirstChild()
+    {
+        return $this === \Nethgui\array_head($this->getParent()->getChildren());
     }
 
     public function prepareView(\Nethgui\View\ViewInterface $view)

--- a/root/usr/share/nethesis/NethServer/Template/SssdConfig/LocalLdapProvider.php
+++ b/root/usr/share/nethesis/NethServer/Template/SssdConfig/LocalLdapProvider.php
@@ -8,7 +8,7 @@ $alert = '';
 $buttons = $view->buttonList($view::BUTTON_HELP);
 
 if($view->getModule()->canUpgradeToSamba()) {
-    $alert = '<div style="max-width: 500px" class="dcalert notification bg-yellow"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> ' . htmlspecialchars($view->translate('canUpgradeToSamba_notification')) . '</div>';
+    $alert = '<div class="dcalert notification bg-yellow"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> ' . htmlspecialchars($view->translate('canUpgradeToSamba_notification')) . '</div>';
     $buttons->insert($view->button('LocalLdapProviderUpgrade', $view::BUTTON_LINK));
 }
 

--- a/root/usr/share/nethesis/NethServer/Template/SssdConfig/LocalLdapProvider.php
+++ b/root/usr/share/nethesis/NethServer/Template/SssdConfig/LocalLdapProvider.php
@@ -4,12 +4,15 @@
 
 echo $view->header('domain')->setAttribute('template', $T('LocalLdapProvider_header'));
 
-
-$buttons = $view->buttonList($view::BUTTON_HELP)
-        ->insert($view->button('LocalLdapProviderUninstall', $view::BUTTON_LINK));
+$alert = '';
+$buttons = $view->buttonList($view::BUTTON_HELP);
 
 if($view->getModule()->canUpgradeToSamba()) {
+    $alert = '<div style="max-width: 500px" class="dcalert notification bg-yellow"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> ' . htmlspecialchars($view->translate('canUpgradeToSamba_notification')) . '</div>';
     $buttons->insert($view->button('LocalLdapProviderUpgrade', $view::BUTTON_LINK));
 }
 
+$buttons->insert($view->button('LocalLdapProviderUninstall', $view::BUTTON_LINK));
+
 echo $buttons;
+echo $alert;

--- a/root/usr/share/nethesis/NethServer/Template/SssdConfig/LocalLdapUpgrade.php
+++ b/root/usr/share/nethesis/NethServer/Template/SssdConfig/LocalLdapUpgrade.php
@@ -5,7 +5,18 @@ $disabledFlags = $view::STATE_READONLY | $view::STATE_DISABLED;
 /* @var $view \Nethgui\Renderer\Xhtml */
 echo $view->header()->setAttribute('template', $T('LocalLdapUpgrade_header'));
 
-echo sprintf('<div class="information"><p>%s</p></div>', htmlspecialchars($T('LocalLdapUpgrade_message')));
+$informationText = sprintf('<p>%s</p>', htmlspecialchars($T('LocalLdapUpgrade_message1')));
+
+if($view->getModule()->canChangeWorkgroup()) {
+    $informationText .= sprintf('<p>%s</p>', htmlspecialchars($T('LocalLdapUpgrade_WS_message1')));
+    $informationText .= sprintf('<p>%s</p>', htmlspecialchars($T('LocalLdapUpgrade_WS_message2')));
+} else {
+    $informationText .= sprintf('<p>%s</p>', htmlspecialchars($T('LocalLdapUpgrade_PDC_message1'))) ;
+}
+
+
+
+echo sprintf('<div class="information">%s</div>', $informationText);
 
 echo $view->textInput('AdRealm');
 echo $view->textInput('AdWorkgroup', $view->getModule()->canChangeWorkgroup() ? 0 : $disabledFlags);
@@ -34,5 +45,9 @@ $view->includeCss('
     font-size: 1.2em;
     max-width: 505px;
     margin-bottom: 1em;
+}
+
+#SssdConfig_LocalLdapUpgrade .information p {
+    margin-bottom: 0.5em;
 }
 ');

--- a/root/usr/share/nethesis/NethServer/Template/SssdConfig/LocalLdapUpgrade.php
+++ b/root/usr/share/nethesis/NethServer/Template/SssdConfig/LocalLdapUpgrade.php
@@ -8,7 +8,7 @@ echo $view->header()->setAttribute('template', $T('LocalLdapUpgrade_header'));
 echo sprintf('<div class="information"><p>%s</p></div>', htmlspecialchars($T('LocalLdapUpgrade_message')));
 
 echo $view->textInput('AdRealm');
-echo $view->textInput('AdWorkgroup', $disabledFlags);
+echo $view->textInput('AdWorkgroup', $view->getModule()->canChangeWorkgroup() ? 0 : $disabledFlags);
 
 $AdIpAddressId = $view->getUniqueId('AdIpAddress');
 


### PR DESCRIPTION
* When the source system has ServerRole=WS, allow changing the Workgroup from UI.
* When the source system is PDC, the Workgroup text input is disabled.
* Display additional information about shared folder credentials