### PR TITLE
Probe remote AD for STARTTLS

### DIFF
--- a/root/usr/sbin/account-provider-test
+++ b/root/usr/sbin/account-provider-test
@@ -199,6 +199,16 @@ if($cmd eq 'dump') {
         my $dse = $ldap->root_dse(attrs => ['defaultNamingContext']);
         my $defaultNamingContext = $dse->get_value('defaultNamingContext');
 
+        # Probe the STARTTLS support
+        if(defined $dse && $attrs{'LdapURI'} !~ /^ldaps:/) {
+            my $response = $ldap->start_tls('verify' => 'none');
+            if($response->is_error()) {
+                $attrs{'StartTls'} = 'disabled';
+            } else {
+                $attrs{'StartTls'} = 'enabled';
+            }
+        }
+
         if ($defaultNamingContext) {
             $attrs{'Provider'} = 'ad';
             $attrs{'Realm'} = uc(join('.', grep { $_ } split(/,?dc=/i, $defaultNamingContext)));

--- a/root/usr/share/nethesis/NethServer/Module/SssdConfig/RemoteAdProvider.php
+++ b/root/usr/share/nethesis/NethServer/Module/SssdConfig/RemoteAdProvider.php
@@ -75,6 +75,17 @@ class RemoteAdProvider extends \Nethgui\Controller\AbstractController  implement
 
         $view['domain'] = $this->getPlatform()->getDatabase('configuration')->getType('DomainName');
         $view['RemoteProviderUnbind'] = array($view->getModuleUrl('../RemoteProviderUnbind'), $view->translate('RemoteProviderUnbind_label', array($view['domain'])));
+
+        $starttlsChoices = array(
+            array('disabled', $view->translate('starttls_disabled')),
+            array('enabled', $view->translate('starttls_enabled')),
+        );
+        // Display StartTls "default" value for backword compatibility
+        if ($this->parameters['StartTls'] === '') {
+            $starttlsChoices[] = array('', $view->translate('starttls_auto'));
+        }
+        $view['StartTlsDatasource'] = $starttlsChoices;
+
         if($this->getRequest()->isValidated()) {
             $view->getCommandList()->show();
             if($this->getRequest()->hasParameter('bindSuccess')) {

--- a/root/usr/share/nethesis/NethServer/Module/SssdConfig/Wizard/AdJoinMember.php
+++ b/root/usr/share/nethesis/NethServer/Module/SssdConfig/Wizard/AdJoinMember.php
@@ -86,7 +86,7 @@ class AdJoinMember extends \Nethgui\Controller\AbstractController  implements \N
             'AdDns' => $addns,
             'Provider' => 'ad',
             'LdapURI' => $probead['LdapURI'],
-            'StartTls' => '',
+            'StartTls' => $probead['StartTls'] ? 'enabled' : 'disabled',
             'UserDN' => $probead['UserDN'],
             'GroupDN' => $probead['GroupDN'],
             'BaseDN' => $probead['BaseDN'],

--- a/root/usr/share/nethesis/NethServer/Template/SssdConfig/RemoteAdProvider.php
+++ b/root/usr/share/nethesis/NethServer/Template/SssdConfig/RemoteAdProvider.php
@@ -7,10 +7,8 @@ echo $view->header('domain')->setAttribute('template', $T('RemoteAdProvider_head
 echo $view->panel()
     ->insert($view->columns()
       ->insert($view->textInput('LdapUri'))
-      ->insert($view->selector('StartTls', $view::SELECTOR_DROPDOWN)->setAttribute('choices', \Nethgui\Widget\XhtmlWidget::hashToDatasource(array(
-        '' => $T('starttls_auto'),
-        'enabled' => $T('starttls_enabled'),
-        'disabled' => $T('starttls_disabled'))))))
+      ->insert($view->selector('StartTls', $view::SELECTOR_DROPDOWN))
+    )
     ->insert($view->textInput('BaseDN'))
     ->insert($view->textInput('UserDN'))
     ->insert($view->textInput('GroupDN'))


### PR DESCRIPTION
After join, sssd[startTls] prop is always set to 0 or 1.
This behavior should ease configuration of third party applications.

NethServer/dev#5365