### PR TITLE
SSSD perl lib: return 0 if starttls is disabled

### DIFF
--- a/lib/perl/NethServer/SSSD.pm
+++ b/lib/perl/NethServer/SSSD.pm
@@ -122,7 +122,7 @@ sub startTls {
     if($self->{'StartTls'} eq 'enabled') {
         return '1';
     } elsif($self->{'StartTls'} eq 'disabled') {
-        return '';
+        return '0';
     }
 
     return $self->bindDN()


### PR DESCRIPTION
Uniform output for accounts-provider-dump