### PR TITLE
Added nethserver-sssd-leave before AD join

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/SssdConfig/Wizard/AdJoinMember.php
+++ b/root/usr/share/nethesis/NethServer/Module/SssdConfig/Wizard/AdJoinMember.php
@@ -110,6 +110,7 @@ class AdJoinMember extends \Nethgui\Controller\AbstractController  implements \N
 
         $descriptors = array(array('pipe', 'r'), array('pipe', 'w'));
         $pipes = array();
+        $this->getPlatform()->signalEvent('nethserver-sssd-leave');
         $ph = proc_open(sprintf('/usr/bin/sudo /usr/sbin/realm join --server-software=active-directory -v -U %s %s 2>&1', escapeshellarg($this->parameters['AdUsername']), escapeshellarg($realm)), $descriptors, $pipes);
         if(is_resource($ph)) {
             fwrite($pipes[0], $this->parameters['AdPassword'] . "\n");

--- a/root/usr/share/nethesis/NethServer/Module/SssdConfig/Wizard/AdJoinMember.php
+++ b/root/usr/share/nethesis/NethServer/Module/SssdConfig/Wizard/AdJoinMember.php
@@ -108,9 +108,9 @@ class AdJoinMember extends \Nethgui\Controller\AbstractController  implements \N
             $this->getLog()->error('Workgroup probe failed!');
         }
 
+        $this->getPlatform()->signalEvent('nethserver-sssd-leave');
         $descriptors = array(array('pipe', 'r'), array('pipe', 'w'));
         $pipes = array();
-        $this->getPlatform()->signalEvent('nethserver-sssd-leave');
         $ph = proc_open(sprintf('/usr/bin/sudo /usr/sbin/realm join --server-software=active-directory -v -U %s %s 2>&1', escapeshellarg($this->parameters['AdUsername']), escapeshellarg($realm)), $descriptors, $pipes);
         if(is_resource($ph)) {
             fwrite($pipes[0], $this->parameters['AdPassword'] . "\n");


### PR DESCRIPTION
When joining AD after changing server name an error is thrown because the domain is already in sssd.conf. Running nethserver-sssd-leave before the join solves this issue.

[NethServer/dev#5399](https://github.com/NethServer/dev/issues/5399)