### PR TITLE
Always try to fix home dir owners in ns6 upgrade

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -196,3 +196,10 @@ validator_actions('ldap-credentials', qw(
 event_actions('post-restore-data', qw(
     nethserver-sssd-ns6homes 60
 ));
+
+#
+# nethserver-directory-ns6upgrade
+#
+event_actions('nethserver-directory-ns6upgrade', qw(
+    nethserver-sssd-ns6homes 40
+));

--- a/root/etc/e-smith/events/actions/nethserver-sssd-ns6homes
+++ b/root/etc/e-smith/events/actions/nethserver-sssd-ns6homes
@@ -20,30 +20,53 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-if [[ ! -f /var/run/.nethserver-upgrade-configdb ]]; then
+#
+# Supported ns6 upgrade paths:
+# - WS/PDC to local AD,
+# - ADS to remote AD,
+# - NONE/WS to local LDAP
+#
+# Methods:
+# - restore from ns6 backup
+# - rsync-upgrade
+#
+
+event=$1
+ns6upgrade_flag=/var/run/.nethserver-upgrade-configdb
+
+if [[ "${event}" == "nethserver-directory-ns6upgrade" ]]; then
+    if [[ -f ${ns6upgrade_flag} ]]; then
+        # We will run lately, in post-restore-data event
+        exit 0
+    fi
+elif [[ ! -f ${ns6upgrade_flag} ]]; then
+    # No flag set, nothing to do
     exit 0
 fi
 
 provider=$(/sbin/e-smith/config getprop sssd Provider)
 
-if [[ ${provider} != "ad" ]]; then
+if [[ ${provider} == "ad" ]]; then
+    primary_group='domain users'
+elif [[ ${provider} == "ldap" ]]; then
+    primary_group='locals'
+else
     exit 0
 fi
 
-
-if ! getent group 'domain users'; then
-    echo "[ERROR] could not find 'domain users' group" 1>&2
+if ! getent group "${primary_group}"; then
+    echo "[ERROR] could not find ${primary_group} group" 1>&2
     exit 1
 fi
 
-echo "[NOTICE] Upgrading home directories permissions for AD account provider"
+echo "[NOTICE] Upgrading home directories permissions for ${provider^^} account provider"
 shopt -s nullglob
 for D in /var/lib/nethserver/home/*; do
-    chown -R "$(basename "${D}")":'domain users' "$D" || ((++errors));
+    chown -R "$(basename "${D}")":"${primary_group}" "$D" || ((++errors));
 done
 
 if (( errors > 0 )); then
-    echo "[ERROR] Failed to chown permissions on home directories"
+    echo "[ERROR] Failed to chown permissions on home directories" 1>&2
     exit 1
 fi
 


### PR DESCRIPTION
We must implement this procedure here, because home directories could be
present also in upgrade from ADS, so neither directory nor dc are
installed.

NethServer/dev#5432