### PR TITLE
Do not open RPM DB in TODO

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -203,3 +203,10 @@ event_actions('post-restore-data', qw(
 event_actions('nethserver-directory-ns6upgrade', qw(
     nethserver-sssd-ns6homes 40
 ));
+
+#
+# event runlevel-adjust
+#
+event_actions('runlevel-adjust', qw(
+    nethserver-sssd-todo-makecache 50
+));

--- a/root/etc/e-smith/events/actions/nethserver-sssd-todo-makecache
+++ b/root/etc/e-smith/events/actions/nethserver-sssd-todo-makecache
@@ -20,6 +20,8 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+flag_path=/var/cache/nethserver-adcredsrequired
+
 #
 # Find NethServer::SSSD Perl module usages in actions and templates then
 # print the list of update events of dependant packages.
@@ -35,7 +37,9 @@ event_watchers=$(find /etc/e-smith/events/nethserver-sssd-save/ -type f -o -type
 # Credentials are optional if no package subscribed nethserver-sssd-save event 
 # or requires NethServer::SSSD
 if [[ -z "$module_usages" && -z "$event_watchers" ]]; then
-    exit 0
+    rm -f ${flag_path}
+else
+    touch ${flag_path}
 fi
 
-exit 2
+

--- a/root/etc/nethserver/todos.d/20ad_credentials
+++ b/root/etc/nethserver/todos.d/20ad_credentials
@@ -24,6 +24,7 @@ import gettext
 import json
 import subprocess
 import sys
+import os.path
 
 out = ''
 
@@ -36,7 +37,7 @@ if(not out):
     exit(1)
 
 # Exit if provider is not AD or LDAP credentials are not required
-if(out['props']['Provider'] != 'ad' or subprocess.call(['/usr/libexec/nethserver/ldap-credentials-optional']) == 0):
+if(out['props']['Provider'] != 'ad' or not os.path.isfile('/var/cache/nethserver-adcredsrequired')):
     exit(0)
 
 if(not 'BindDN' in out['props'] or not out['props']['BindDN']):

--- a/root/usr/share/nethesis/NethServer/Module/SssdConfig/RemoteAdProvider.php
+++ b/root/usr/share/nethesis/NethServer/Module/SssdConfig/RemoteAdProvider.php
@@ -90,7 +90,7 @@ class RemoteAdProvider extends \Nethgui\Controller\AbstractController  implement
     {
         static $response;
         if( ! isset($response)) {
-            $response = $this->getPlatform()->exec('/usr/libexec/nethserver/ldap-credentials-optional')->getExitCode() == 2;
+            $response = @file_exists('/var/cache/nethserver-adcredsrequired');
         }
         return $response;
     }


### PR DESCRIPTION
The TODO handler could be killed: store information in a cache-file and
read from it (faster and safer).

NethServer/dev#5440