### PR TITLE
Silence Perl warning in default value for bindDN()

### DIFF
--- a/lib/perl/NethServer/SSSD.pm
+++ b/lib/perl/NethServer/SSSD.pm
@@ -333,7 +333,7 @@ sub bindUser {
     my $self = shift;
     return $self->{'BindUser'} if ($self->{'BindUser'});
 
-    my $bindUser = [split(/,/, $self->bindDN())]->[0];
+    my $bindUser = [split(/,/, $self->bindDN())]->[0] || '';
     $bindUser =~ s/^.+=//;
     if ($self->isAD()) {
         $bindUser =~ s/^.+\\//;


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/5476

the variable is initialized if   bindDN() is not set