### PR TITLE
Do not use Samba machine secret in Domain accounts page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -266,17 +266,18 @@ configuration hooks`_).
 Leave and Re-Join Active Directory
 ----------------------------------
 
-To leave a remote AD go to the :guilabel:`Accounts provider` page. For local AD
-provider, this is the **manual leave procedure** ::
+To leave a **remote AD** go to the :guilabel:`Accounts provider` page. 
 
-    config setprop sssd Realm '' Workgroup '' Provider none
-    signal-event nethserver-sssd-leave
+For **local AD** provider, this is the manual leave procedure ::
 
-If the machine password or system keytab get corrputed, joining again the DC can fix them: ::
+    realm leave
+    realm leave # two times
+
+If the machine password or system keytab get corrupted, joining again the DC can fix them: ::
     
-    realm join -U administrator $(hostname -d)
+    realm join -U admin $(config getprop sssd Realm)
 
-...at prompt, type the administrator (or admin) password, then: ::
+...at prompt, type the admin's password, then: ::
 
     signal-event nethserver-sssd-save
 

--- a/README.rst
+++ b/README.rst
@@ -220,6 +220,29 @@ The Dashboard account counters are provided by:
 All those helpers support the ``-A`` flag, to include hidden entries, 
 and the ``-s`` flag to return entries without ``@domain`` suffix.
 
+AD LDAP search
+--------------
+
+The Samba ``net ads search -k`` command can run an LDAP search against the AD
+LDAP servers. The command requires a valid Kerberos ticket and a configured
+environment variable, ``KRB5CCNAME``, pointing to it.
+
+The ``krb5exec`` command can set up the Kerberos ticket by authenticating with
+the machine credentials, providing the same environment where the UI helpers
+run, as explained in the previous section.
+
+Putting the two commands together, the following command retrieves the ``admin``
+account record from AD LDAP. ::
+    
+    krb5exec net ads search -k sAMAccountName=admin
+
+The same command with ``ldapsearch``
+
+    krb5exec ldapsearch -Y GSSAPI -b <BIND_PATH> -h <LDAP_SERVER_NAME> sAMAccountName=admin
+
+Replace ``<BIND_PATH>`` and ``<LDAP_SERVER_NAME>`` with values provided by ::
+    
+    net ads info
 
 NethServer::SSSD
 ----------------

--- a/root/usr/libexec/nethserver/net-ads-info
+++ b/root/usr/libexec/nethserver/net-ads-info
@@ -25,16 +25,14 @@ set -e
 workgroup=$(testparm -s -d 0 --parameter-name=workgroup 2>/dev/null)
 systemname=$(hostname -s)
 netbiosname=${systemname:0:15}\$
-export KRB5CCNAME="/tmp/krb5cc_$(id -u)"
-perl -MNethServer::SSSD -MNethServer::LdapClient -e 'NethServer::LdapClient::_init_kerberos(NethServer::SSSD->new());'
 
 echo "NetBIOS domain name: $workgroup"
 
 exec timeout --signal=HUP --kill-after=4 4 /usr/bin/bash -s <<EOF
 net ads info
 echo ""
-klist -s && echo -e "Join is OK\n"
-net ads search -k "(&(sAMAccountName=${netbiosname})(objectCategory=computer))" \
+krb5exec klist -s && echo -e "Join is OK\n"
+krb5exec net ads search -k "(&(sAMAccountName=${netbiosname})(objectCategory=computer))" \
         name \
         sAMAccountName \
         distinguishedName \

--- a/root/usr/libexec/nethserver/net-ads-info
+++ b/root/usr/libexec/nethserver/net-ads-info
@@ -25,15 +25,16 @@ set -e
 workgroup=$(testparm -s -d 0 --parameter-name=workgroup 2>/dev/null)
 systemname=$(hostname -s)
 netbiosname=${systemname:0:15}\$
+export KRB5CCNAME="/tmp/krb5cc_$(id -u)"
+perl -MNethServer::SSSD -MNethServer::LdapClient -e 'NethServer::LdapClient::_init_kerberos(NethServer::SSSD->new());'
 
 echo "NetBIOS domain name: $workgroup"
 
 exec timeout --signal=HUP --kill-after=4 4 /usr/bin/bash -s <<EOF
 net ads info
 echo ""
-net ads testjoin
-echo ""
-net ads search -P "(&(sAMAccountName=${netbiosname})(objectCategory=computer))" \
+klist -s && echo -e "Join is OK\n"
+net ads search -k "(&(sAMAccountName=${netbiosname})(objectCategory=computer))" \
         name \
         sAMAccountName \
         distinguishedName \

--- a/root/usr/libexec/nethserver/smbads
+++ b/root/usr/libexec/nethserver/smbads
@@ -32,7 +32,7 @@ use Time::Local;
 my %opts;
 my $verbose = 0;
 
-getopts('vu:F:', \%opts);
+getopts('v', \%opts);
 
 if($opts{v}) {
     $verbose = 1;
@@ -46,92 +46,13 @@ if(! $command) {
 }
 
 #
-# test: exec() `net ads testjoin` command and report its exit code
-#
-if($command eq 'test') {
-
-    ! $verbose && open(STDOUT, '>/dev/null');
-    # Use `-k`, kerberos auth, to avoid the password prompt. It seems
-    # the password in secrets.tdb is checked anyway.
-    exec(qw(/usr/bin/net -k ads testjoin)) || die;
-}
-
-#
-# join: exec() `net ads join` and initialize daemons keytabs
-#
-if($command eq 'join') {
-
-    my $user = $opts{u} || get_machine_principal();
-    my $file = $opts{F};
-    my $useKerberos = 0;
-
-    if($file) {
-        open(STDIN, '<', $file) or die("[ERROR] Could not read password file $file: $!\n");
-    } else {
-        $useKerberos = 1;
-    }
-
-    ! $verbose && open(STDOUT, '>/dev/null');
-
-    if($useKerberos) {
-        kerberos_initialize($user);
-    }
-
-    if( ! net_ads_join($useKerberos, $user)) {
-        warn("[ERROR] $0: ADS join failed\n");
-        exit 3;
-    }
-
-    seek(STDIN, 0, SEEK_SET);
-
-    if( ! init_keytabs($useKerberos, $user)) {
-        warn("[ERROR] $0: failed to initialize keytabs\n");
-        exit 4;
-    }
-
-    if($useKerberos) {
-        kerberos_destroy();
-    }
-
-    if( ! refresh_credential_caches($service)) {
-        warn("[ERROR] $0: failed initialize credential caches\n");
-        exit 6;
-    }
-
-    exit 0;
-}
-
-#
-# changepassword: exec() `net ads changetrustpw`
-#
-if($command eq 'changepassword') {
-    my $user = $opts{u} || get_machine_principal();
-
-    ! $verbose && open(STDOUT, '>/dev/null');
-
-    kerberos_initialize($user);
-
-    # Use `-k`, kerberos auth, to avoid the password prompt:
-    system(qw(/usr/bin/net -k ads changetrustpw));
-
-    if( ! init_keytabs(1, get_machine_principal())) {
-        warn("[ERROR] $0: failed to initialize keytabs\n");
-        exit 4;
-    }
-
-    kerberos_destroy();
-
-    exit 0;
-}
-
-#
 # initkeytab
 #
 if($command eq 'initkeytab') {
     my $machine = get_machine_principal();
     ! $verbose && open(STDOUT, '>/dev/null');
     kerberos_initialize($machine);
-    if( ! init_keytabs(1, $machine)) {
+    if( ! init_keytabs()) {
         warn("[ERROR] $0: failed to initialize keytabs\n");
         exit 5;
     }
@@ -140,83 +61,22 @@ if($command eq 'initkeytab') {
 }
 
 
-#
-# tgt: test TGT validity for the given service. If the TGT is expired
-# or is missing request a new one
-#
-if($command eq 'tgt') {
-
-    # Redirect STDOUT to null device if not verbose:
-    if( ! $verbose) {
-        open(STDOUT, '>/dev/null');
-    }
-
-    if( ! refresh_credential_caches($service)) {
-        exit 6;
-    }
-
-    exit 0;
-}
-
-#
-# env: output environment variables to configure kerberos library for a specific service
-#
-if($command eq 'env') {
-    if( ! $service) {
-        die "[ERROR] you must specify a service name\n";
-    }
-
-    my $configDb = esmith::ConfigDB->open_ro;
-
-    if( ! $configDb) {
-        die "[ERROR] could not open ConfigDB\n";
-    }
-
-    my ($ktConfig) = grep { $_->{service} eq $service } read_krb_configs();
-
-    my $ktName = $ktConfig->{kt_path};
-    my $ccName = $ktConfig->{cc_path};
-
-    printf "export KRB5CCNAME='%s'\n", $ccName if($ccName) ;
-    printf "export KRB5_KTNAME='%s'\n", $ktName if($ktName) ;
-
-    exit 0;
-
-}
-
-warn("[ERROR] Usage: $0 [-u username] [-F filename] initkeytab|test|join|changepassword|tgt|env [service]\n");
+warn("[ERROR] Usage: $0 initkeytab\n");
 exit 1;
 
 #
 # SUBROUTINES
 #
 
-sub net_ads_join()
-{
-    my $useKerberos = shift;
-    my $user = shift;
-
-    my %cfg = esmith::ConfigDB->as_hash();
-    my $osName = $cfg{sysconfig}{ProductName} || 'NethServer';
-    my $osVersion = $cfg{sysconfig}{Version} || '1.0';
-
-    my $exitCode = system(qw(/usr/bin/net ads join), $useKerberos ? ('-k') : ('-U', $user), "osName=$osName", "osVer=$osVersion");
-
-    return ($exitCode == 0);
-}
-
 sub init_keytabs()
 {
-    my $useKerberos = shift;
-    my $user = shift;
 
     my @ktConfigs = read_krb_configs();
 
 
     # Initialize the system keytab, by adding required
     # primaries. 'cifs' is always added:
-    my $exitCode = system(qw(/usr/bin/net ads keytab add),
-                          $useKerberos ? ('-k') : ('-U', $user),
+    my $exitCode = system(qw(/usr/bin/net ads keytab add -k),
                           keys %{{map { (map { $_ => 1 } 'cifs', @{$_->{primary}}) } @ktConfigs}}
         );
 
@@ -356,139 +216,6 @@ sub get_machine_principal()
     return $principal;
 }
 
-
-#
-# Get the future status of the TGT, after the given $period has elapsed.
-#
-# 0 = ticket expired
-# 1 = ticket is renewable
-# 2 = ticket is valid
-#
-sub tgt_status
-{
-    my $ccPath = shift;
-    my $period = shift;
-
-    my $cch = Authen::Krb5::cc_resolve('FILE:' . $ccPath);
-    if( ! $cch) {
-        return 0;
-    }
-
-    my $iterator = $cch->start_seq_get();
-
-    if( ! $iterator) {
-        return 0;
-    }
-
-    my $creds;
-
-    while($creds = Authen::Krb5::Ccache::next_cred($cch, $iterator)) {
-        my $server = $creds->server();
-        if($server =~ m{^krbtgt/}) {
-            last;
-        }
-    }
-
-    if( ! defined $creds) {
-        warn "[WARNING] no krbtgt credentials found\n";
-        return 0;
-    }
-
-
-    my $tolerance = int($period * 5 / 100);
-
-    my $now = time();
-
-    my $n = $now + $tolerance;
-    my $d = $now + $period + $tolerance;
-
-    # endtime() will newer exceed renew_till():
-    my $endt = $creds->endtime();
-
-    $cch->end_seq_get($iterator);
-
-    #
-    # now, current time()
-    # P, given period
-    # t, tolerance = 5% of P
-    # n = now + tolerance
-    # d, deadline = now + P + t
-    #
-    # CCCCCCCCBBBBBBBBBBBBBBBBBBBBBBBBBBBBBAAAA
-    # --|----|-----------------------|----|----
-    #  now  n=now+t                  P   d=P+t
-    #
-
-    # case A
-    if($endt > $d) {
-        return 2; # ticket is valid and will be still valid after
-                  # $period. No action needed.
-    }
-
-    # case B
-    if($endt > $n) {
-        return 1; # ticket will not be valid after period, but it can
-                  # be still renewed.
-    }
-
-    # case C
-    return 0; # ticket is not renewable. A new ticket is required.
-
-}
-
-
-sub refresh_credential_caches()
-{
-    my $service = shift;
-    my @cfgs = ();
-
-    if($service) {
-        @cfgs = grep { $_->{service} eq $service } read_krb_configs();
-    } else {
-        @cfgs = read_krb_configs();
-    }
-
-    my $errors = 0;
-    my $principal = get_machine_principal();
-
-    my $ctx = Authen::Krb5::init_context();
-    if( ! $ctx) {
-        warn "[ERROR] failed to initialize krb5 context\n";
-        return 0;
-    }
-
-    # Use the default keytab for machine credentials:
-    delete $ENV{KRB5_KTNAME};
-
-    foreach (@cfgs) {
-        $ENV{KRB5CCNAME} = $_->{cc_path};
-
-        my $val = tgt_status($_->{cc_path}, 3600);
-        my $sname = $_->{service};
-
-        if($val == 1) {
-            print "Renewing kerberos TGT for service $sname\n";
-            system(qw(/usr/bin/kinit -R));
-        } elsif($val == 2) {
-            print "Using valid kerberos TGT for service $sname\n";
-            next;
-        } else {
-            print "Requesting kerberos TGT for service $sname using $principal\n";
-            system(qw(/usr/bin/kinit -k), $principal);
-        }
-
-        if($? != 0) {
-            $errors ++;
-        }
-
-        chown $_->{owner}->uid, -1, $_->{cc_path};
-    }
-
-    return ($errors == 0 ? 1 : 0);
-}
-
-
-
 sub kerberos_initialize($)
 {
     my $user = shift;
@@ -497,7 +224,6 @@ sub kerberos_initialize($)
     system('/usr/bin/kinit', '-k', $user);
     return ($? == 0 ? 1 : 0);
 }
-
 
 sub kerberos_destroy()
 {

--- a/root/usr/sbin/krb5exec
+++ b/root/usr/sbin/krb5exec
@@ -1,0 +1,33 @@
+#!/usr/bin/bash
+
+#
+# Copyright (C) 2018 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+if [[ $# == 0 ]]; then
+    echo "Authenticate with Kerberos machine account credentials and run the given command" 1>&2
+    echo "Usage: $0 command [args]" 1>&2
+    exit 1
+fi
+
+perl -MNethServer::SSSD -MNethServer::LdapClient -e 'NethServer::LdapClient::_init_kerberos(NethServer::SSSD->new());'
+export KRB5CCNAME="/tmp/krb5cc_$(id -u)"
+
+exec "${@}"
+

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Account.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Account.php
@@ -14,4 +14,4 @@ $L['AccountProvider_Error_4'] = 'Account provider warning: size limit exceeded (
 $L['AccountProvider_Error_104'] = 'Account provider connection reset by peer: check if the server supports SSL/TLS connections';
 $L['AccountProvider_Error_110'] = 'Account provider connection timed out';
 $L['AccountProvider_Error_111'] = 'Account provider connection refused';
-
+$L['AccountProvider_Error_82'] = 'LDAP client internal error (AccountProvider_Error_82)';

--- a/root/usr/share/nethesis/NethServer/Module/SssdConfig/Wizard/AdJoinMember.php
+++ b/root/usr/share/nethesis/NethServer/Module/SssdConfig/Wizard/AdJoinMember.php
@@ -127,7 +127,7 @@ class AdJoinMember extends \Nethgui\Controller\AbstractController  implements \N
         if ($err === 0) {
 
             $this->getLog()->notice("Active Directory domain $realm was joined succesfully!");
-            $this->getLog()->notice("NetBIOS domain name is " . $probead['Workgroup']);
+            $this->getLog()->notice("NetBIOS domain name is " . $probeworkgroup['Workgroup']);
             $configDb->setProp('sssd', array('status' => 'enabled'));
             $this->getPlatform()->signalEvent('nethserver-sssd-save');
 


### PR DESCRIPTION
The `Status > Domain accounts` page is the last Server Manager page that reads the machine password from Samba `secrets.tdb`. This PR implements Kerberos based authentication also for it.

Furthermore adds the `krb5exec` helper, to run any command in an initialized Kerberos environment (see README).

Some unused code in `smbads` has been removed.