### PR TITLE
Arm integration ease time out read AD info

### DIFF
--- a/root/usr/libexec/nethserver/net-ads-info
+++ b/root/usr/libexec/nethserver/net-ads-info
@@ -28,7 +28,7 @@ netbiosname=${systemname:0:15}\$
 
 echo "NetBIOS domain name: $workgroup"
 
-exec timeout --signal=HUP --kill-after=4 4 /usr/bin/bash -s <<EOF
+exec timeout --signal=HUP --kill-after=10 10 /usr/bin/bash -s <<EOF
 net ads info
 echo ""
 krb5exec klist -s && echo -e "Join is OK\n"


### PR DESCRIPTION
NethServer/dev#5610

On systems with low resources like arm systems with a local AD account provider installed the info page in the server-manger keeps reporting "Could not connect to accounts provider!"
This despite the AD is working properly.

Note the increase of timeout from 4 to 10 is quite arbitrary i.e did not really determine if lower timeout would work to.  As long as  [/usr/share/nethesis/NethServer/Module/Sssd/Index.php](https://github.com/NethServer/nethserver-sssd/blob/master/root/usr/share/nethesis/NethServer/Module/Sssd/Index.php#L43) is the only place the `net-ads-info` script is called this is none critical.


