### PR TITLE
Enable ShellOverrideStatus by default

### DIFF
--- a/root/etc/e-smith/db/configuration/defaults/sssd/ShellOverrideStatus
+++ b/root/etc/e-smith/db/configuration/defaults/sssd/ShellOverrideStatus
@@ -1,1 +1,1 @@
-disabled
+enabled


### PR DESCRIPTION
New NS 7.8.2003 defaults: promote new SSH policy and user settings page.

NethServer/dev#6121