### PR TITLE
Honor PassExpires prop for local LDAP provider

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -121,6 +121,10 @@ event_actions('password-policy-update', qw(
     nethserver-sssd-clear-cache 10
 ));
 
+event_services('password-policy-update', qw(
+    sssd reload
+));
+
 # actions for myhostname validator
 validator_actions('myhostname', qw(
     failifjoin 00

--- a/createlinks
+++ b/createlinks
@@ -117,6 +117,10 @@ event_actions($_, qw(
 # Clear SSSD before password-policy-update extra actions
 #--------------------------------------------------------
 
+event_templates('password-policy-update', qw(
+    /etc/sssd/sssd.conf
+));
+
 event_actions('password-policy-update', qw(
     nethserver-sssd-clear-cache 10
 ));

--- a/root/etc/e-smith/templates/etc/sssd/sssd.conf/01provider_config
+++ b/root/etc/e-smith/templates/etc/sssd/sssd.conf/01provider_config
@@ -11,7 +11,6 @@
         $provider_config .= "ldap_user_search_base = " . $sssd_object->userDN() . "\n";
         $provider_config .= "ldap_group_search_base = " . $sssd_object->groupDN() . "\n";
         $provider_config .= "ldap_tls_reqcert = never\n";
-        $provider_config .= "ldap_pwd_policy = shadow\n";
     } elsif ($provider eq 'ad') {
         $provider_config .= "access_provider = ad\n";
         $provider_config .= "ad_domain = " . lc($sssd{'Realm'}) . "\n"; # force lowercase

--- a/root/etc/e-smith/templates/etc/sssd/sssd.conf/01provider_ldap_pp
+++ b/root/etc/e-smith/templates/etc/sssd/sssd.conf/01provider_ldap_pp
@@ -1,0 +1,19 @@
+{
+    #
+    # 01provider_ldap_pp -- read password expiration policy from LDAP shadow attributes
+    #
+    if ( ! $sssd_object->isLdap()) {
+        return '';
+    }
+
+    my $pass_expires = $passwordstrength{'PassExpires'} || 'yes';
+
+    if ($sssd_object->isLocalProvider() && $pass_expires eq 'no') {
+        # Local account provider policy depends on PassExpires prop value
+        $provider_config .= "ldap_pwd_policy = none\n";
+    } else {
+        # Remote account provider always try to honor the shadow attributes
+        $provider_config .= "ldap_pwd_policy = shadow\n";
+    }
+    '';
+}


### PR DESCRIPTION
Shadow LDAP attributes are completely ignored if `PassExpires=no`

https://github.com/NethServer/dev/issues/6387