### PR TITLE
Fix SPNs management for Samba 4.10

### DIFF
--- a/nethserver-sssd.spec
+++ b/nethserver-sssd.spec
@@ -11,7 +11,7 @@ BuildRequires:  nethserver-devtools
 Requires:       realmd, sssd, adcli, nethserver-lib
 # send expiring password warnings: 
 Requires: mailx, postfix, anacron
-Requires:  samba-common-tools
+Requires: samba-common-tools
 Requires: krb5-workstation
 Requires: python-tdb
 Requires: tdb-tools

--- a/nethserver-sssd.spec
+++ b/nethserver-sssd.spec
@@ -11,7 +11,7 @@ BuildRequires:  nethserver-devtools
 Requires:       realmd, sssd, adcli, nethserver-lib
 # send expiring password warnings: 
 Requires: mailx, postfix, anacron
-Requires: samba-common-tools >= 4.9.1
+Requires:  samba-common-tools
 Requires: krb5-workstation
 Requires: python-tdb
 Requires: tdb-tools

--- a/root/usr/libexec/nethserver/smbads
+++ b/root/usr/libexec/nethserver/smbads
@@ -76,8 +76,8 @@ sub init_keytabs()
 
     # Initialize the system keytab, by adding required
     # primaries. 'cifs' is always added:
-    my $exitCode = system(qw(/usr/bin/net ads keytab add -k),
-                          keys %{{map { (map { $_ => 1 } 'cifs', @{$_->{primary}}) } @ktConfigs}}
+    my $exitCode = system(qw(/usr/bin/net ads keytab add -k cifs),
+                          keys %{{map { (map { $_ => 1 } @{$_->{primary}}) } @ktConfigs}}
         );
 
     if($exitCode != 0) {

--- a/root/usr/libexec/nethserver/smbads
+++ b/root/usr/libexec/nethserver/smbads
@@ -76,7 +76,7 @@ sub init_keytabs()
 
     # Initialize the system keytab, by adding required
     # primaries. 'cifs' is always added:
-    my $exitCode = system(qw(/usr/bin/net ads keytab add_update_ads -k),
+    my $exitCode = system(qw(/usr/bin/net ads keytab add -k),
                           keys %{{map { (map { $_ => 1 } 'cifs', @{$_->{primary}}) } @ktConfigs}}
         );
 


### PR DESCRIPTION
The samba-common package was upgraded to 4.10.16 with NS 7.9 and changed the way the machine account is created in the AD LDAP during the domain join procedure.

The resulting LDAP entry prevents `smbads` to self-add SPNs to LDAP as described by issue NethServer/dev#6446.

It seems the only real scenario where additional SPNs are required in the LDAP entry is Dovecot.

This PR **disables** the attempt of adding SPNs to the AD LDAP machine entry and **documents** how to perform the action manually.
Note that the existing `HOST/` SPNs are enough for both `cifs` and `HTTP` service primaries because of the default `sPNMappings` setup of AD. It is possible to retrieve the default value with

    ldapsearch -Y GSSAPI -H ldap://nsdc-vm1.ad.dpnet.nethesis.it -b "CN=Directory Service,CN=Windows NT,CN=Services,CN=Configuration,DC=ad,DC=dpnet,DC=nethesis,DC=it" sPNMappings

```
sPNMappings: host=alerter,appmgmt,cisvc,clipsrv,browser,dhcp,dnscache,replicat
 or,eventlog,eventsystem,policyagent,oakley,dmserver,dns,mcsvc,fax,msiserver,i
 as,messenger,netlogon,netman,netdde,netddedsm,nmagent,plugplay,protectedstora
 ge,rasman,rpclocator,rpc,rpcss,remoteaccess,rsvp,samss,scardsvr,scesrv,seclog
 on,scm,dcom,cifs,spooler,snmp,schedule,tapisrv,trksvr,trkwks,ups,time,wins,ww
 w,http,w3svc,iisadmin,msdtc
``` 

The `smbads` tool still runs during the `nethserver-sssd-save`, `nethserver-mail-server-update`, `nethserver-squid-update` events and creates the service keytabs adding the required records automatically. The actual keytab paths are

- /var/lib/misc/nsrv-squid.keytab
- /var/lib/dovecot/krb5.keytab

See also

- https://bugzilla.samba.org/show_bug.cgi?id=14116
- https://github.com/NethServer/dev/issues/6446
- https://github.com/NethServer/dev/issues/5840
- https://wiki.samba.org/index.php/Authenticating_Dovecot_against_Active_Directory