### PR TITLE
Documentation: import_groups typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -419,7 +419,7 @@ It is possible to create groups from a TSV (Tab Separated Values) file with the 
 
 Sample invocation: ::
 
-  import_users groups.tsv
+  import_groups groups.tsv
 
 Alternative separator character: ::
 


### PR DESCRIPTION
One of the import_groups sections example says import_users instead of import_groups